### PR TITLE
Fixed missing argument label 'preferredTimescale'

### DIFF
--- a/ios/Classes/SwiftGaplessAudioLoopPlugin.swift
+++ b/ios/Classes/SwiftGaplessAudioLoopPlugin.swift
@@ -93,7 +93,7 @@ public class SwiftGaplessAudioLoopPlugin: NSObject, FlutterPlugin {
                     let positionInMillis: Int = myArgs["position"] as? Int {
                     
                     let player = SwiftGaplessAudioLoopPlugin.players[playerId]
-                    player?.player?.seek(to: CMTimeMakeWithSeconds(Float64(positionInMillis / 1000), Int32(NSEC_PER_SEC)))
+                    player?.player?.seek(to: CMTimeMakeWithSeconds(Float64(positionInMillis / 1000), preferredTimescale: Int32(NSEC_PER_SEC)))
                 }
         }
     }


### PR DESCRIPTION
**Fixed a Flutter iOS build error.**

```
error: missing argument label 'preferredTimescale:' in call
                        player?.player?.seek(to: CMTimeMakeWithSeconds(Float64(positionInMillis / 1000), Int32(NSEC_PER_SEC)))
                                                                      
                                                                             
```

> Could not build the precompiled application for the device.
> 
> Error launching application on iPhone.